### PR TITLE
Vesting: add position termination functionality

### DIFF
--- a/contracts/vesting/src/msg.rs
+++ b/contracts/vesting/src/msg.rs
@@ -30,6 +30,10 @@ pub enum ExecuteMsg {
         user: String,
         vest_schedule: Schedule,
     },
+    /// Terminate a vesting position, collect all unvested tokens
+    TerminatePosition {
+        user: String,
+    },
     /// Withdraw vested and unlocked MARS tokens
     Withdraw {},
     /// Transfer the contract's ownership to another account


### PR DESCRIPTION
Add an owner-only function `terminate_position`. All tokens that have already been vested will remain in the position. All unvested tokens will be sent to the owner.