### PR TITLE
Fix a bug related to Mars Hub genesis

### DIFF
--- a/contracts/delegator/Cargo.toml
+++ b/contracts/delegator/Cargo.toml
@@ -13,7 +13,6 @@ cosmwasm-schema = "1.1"
 cosmwasm-std = { version = "1.1", features = ["staking"] }
 cw2 = "0.15"
 cw-storage-plus = "0.15"
-cw-utils = "0.15"
 mars-types = { path = "../../packages/types" }
 thiserror = "1.0"
 

--- a/contracts/delegator/src/contract.rs
+++ b/contracts/delegator/src/contract.rs
@@ -15,11 +15,11 @@ pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    execute::init(deps, info, msg)
+    execute::init(deps, msg)
 }
 
 #[entry_point]
@@ -37,6 +37,7 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response<MarsMsg>, ContractError> {
     match msg {
+        ExecuteMsg::Bond {} => execute::bond(deps, env),
         ExecuteMsg::Unbond {} => execute::unbond(deps, env),
         ExecuteMsg::Refund {} => execute::refund(deps, env),
     }

--- a/contracts/delegator/src/error.rs
+++ b/contracts/delegator/src/error.rs
@@ -1,5 +1,4 @@
 use cosmwasm_std::StdError;
-use cw_utils::PaymentError;
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
@@ -7,10 +6,10 @@ pub enum ContractError {
     #[error(transparent)]
     Std(#[from] StdError),
 
-    #[error(transparent)]
-    Payment(#[from] PaymentError),
+    #[error("contract does not hold any coin to be bonded")]
+    NothingToBond,
 
-    #[error("contract does not hold any coin")]
+    #[error("contract does not hold any coin to be refunded")]
     NothingToRefund,
 
     #[error("ending time is not reached yet! ending: {ending_time}, current: {current_time}")]

--- a/contracts/delegator/src/msg.rs
+++ b/contracts/delegator/src/msg.rs
@@ -27,6 +27,9 @@ pub enum SudoMsg {
 
 #[cw_serde]
 pub enum ExecuteMsg {
+    /// Delegate tokens that the contract holds evenly to the current validator set.
+    Bond {},
+
     /// Unbond the delegations.
     ///
     /// Can be invoked by anyone after `ending_time` is reached.


### PR DESCRIPTION
Currently, the delegator contract makes delegation to validators during instantiation, which happens during the chain's genesis.

Unfortunately, this is in conflict with how Cosmos SDK handles genesis. Specifically, the SDK invokes the `InitGenesis` method on each module, which may optionally return a validator set update. The SDK requires that during genesis, **only one** module can return a valset update. Typically, this module is the `genutils` module. However, if our delegator contract makes a delegation during genesis, the `wasm` module will also attempt to update the valset, resulting in the following error:

```
panic: validator InitGenesis updates already set by a previous module
```

The fix: Instead of making the delegation during genesis, the contract simply receives the MARS tokens and holds it. Once the chain is running, anyone can invoke the `bond` execute method to delegate the tokens evenly to all active validators.