### PR TITLE
New delegation mechanism

### DIFF
--- a/contracts/delegator/src/contract.rs
+++ b/contracts/delegator/src/contract.rs
@@ -19,12 +19,16 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    execute::init(deps, msg)
+    execute::init(deps, msg.bond_denom)
 }
 
 #[entry_point]
-pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> StdResult<Response<MarsMsg>> {
+pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response<MarsMsg>, ContractError> {
     match msg {
+        SudoMsg::Bond {
+            validators,
+            ending_time,
+        } => execute::bond(deps, env, validators, ending_time),
         SudoMsg::ForceUnbond {} => execute::force_unbond(deps, env),
     }
 }
@@ -37,7 +41,6 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response<MarsMsg>, ContractError> {
     match msg {
-        ExecuteMsg::Bond {} => execute::bond(deps, env),
         ExecuteMsg::Unbond {} => execute::unbond(deps, env),
         ExecuteMsg::Refund {} => execute::refund(deps, env),
     }

--- a/contracts/delegator/src/error.rs
+++ b/contracts/delegator/src/error.rs
@@ -6,6 +6,9 @@ pub enum ContractError {
     #[error(transparent)]
     Std(#[from] StdError),
 
+    #[error("a delegation program already exists")]
+    DelegationExists,
+
     #[error("contract does not hold any coin to be bonded")]
     NothingToBond,
 

--- a/contracts/delegator/src/error.rs
+++ b/contracts/delegator/src/error.rs
@@ -12,18 +12,20 @@ pub enum ContractError {
     #[error("contract does not hold any coin to be refunded")]
     NothingToRefund,
 
+    #[error("validator with address `{address}` does not exist")]
+    ValidatorNotFound {
+        address: String,
+    },
+
+    #[error("invalid ending time `{ending_time}`: must be later than current time {current_time}")]
+    InvalidEndingTime {
+        ending_time: u64,
+        current_time: u64,
+    },
+
     #[error("ending time is not reached yet! ending: {ending_time}, current: {current_time}")]
     EndingTimeNotReached {
         ending_time: u64,
         current_time: u64,
     },
-}
-
-impl ContractError {
-    pub fn ending_time_not_reached(ending_time: u64, current_time: u64) -> Self {
-        Self::EndingTimeNotReached {
-            ending_time,
-            current_time,
-        }
-    }
 }

--- a/contracts/delegator/src/execute.rs
+++ b/contracts/delegator/src/execute.rs
@@ -135,9 +135,7 @@ pub fn get_delegation_msgs(
             } else {
                 0
             };
-
             let tokens_for_validator = tokens_per_validator + remainder_for_validator;
-
             StakingMsg::Delegate {
                 validator: validator.address,
                 amount: coin(tokens_for_validator, denom),

--- a/contracts/delegator/src/execute.rs
+++ b/contracts/delegator/src/execute.rs
@@ -128,7 +128,7 @@ pub fn get_delegation_msgs(
             // ```
             // let remainder_for_validator = u128::from((idx + 1) as u128 <= remainder);
             // ```
-            // however, I feel this is much less readable what we have now.
+            // however, I feel this is much less readable than what we have now.
             #[allow(clippy::bool_to_int_with_if)]
             let remainder_for_validator = if (idx + 1) as u128 <= remainder {
                 1

--- a/contracts/delegator/src/execute.rs
+++ b/contracts/delegator/src/execute.rs
@@ -52,7 +52,8 @@ pub fn bond(
             &bond_denom,
         )?)
         .add_attribute("action", "periphery/delegator/bond")
-        .add_attribute("amount", balance.to_string()))
+        .add_attribute("amount", balance.to_string())
+        .add_attribute("ending_time", ending_time.to_string()))
 }
 
 pub fn force_unbond(deps: DepsMut, env: Env) -> Result<Response<MarsMsg>, ContractError> {

--- a/contracts/delegator/src/msg.rs
+++ b/contracts/delegator/src/msg.rs
@@ -1,35 +1,43 @@
+use std::collections::BTreeSet;
+
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
 #[cw_serde]
-pub struct Config {
+pub struct InstantiateMsg {
     /// Denomination of the coin that will be staked.
     pub bond_denom: String,
-
-    /// The ending time for the delegation program, as UNIX timestamp.
-    ///
-    /// Once this time has elapsed, anyone can invoke the `unbond` method to unbond the delegations.
-    ///
-    /// Additionally, Mars Hub governance can decide to prematurely end the delegation program if
-    /// they see fit, ignoring the ending time, by invoking the `force_unbond` sudo message.
-    pub ending_time: u64,
 }
-
-pub type InstantiateMsg = Config;
 
 #[cw_serde]
 pub enum SudoMsg {
+    /// Delegate tokens that the contract holds evenly to the specified validators.
+    Bond {
+        /// Addresses of validators to delegate to.
+        ///
+        /// We use a BTreeSet (instead of a Vec) to automatically filter off
+        /// duplicates.
+        validators: BTreeSet<String>,
+
+        /// The ending time for the delegation program, as UNIX timestamp.
+        ///
+        /// Once this time has elapsed, anyone can invoke the `unbond` method to
+        /// unbond the delegations.
+        ///
+        /// Additionally, Mars Hub governance can decide to prematurely end the
+        /// delegation program if they see fit, ignoring the ending time, by
+        /// invoking the `force_unbond` sudo message.
+        ending_time: u64,
+    },
+
     /// Forcibly unbond the delegations.
     ///
-    /// This "sudo" message can only be invoked by the gov module, and ignores whether the
-    /// `ending_time` has been reached.
+    /// This "sudo" message can only be invoked by the gov module, and ignores
+    /// whether the `ending_time` has been reached.
     ForceUnbond {},
 }
 
 #[cw_serde]
 pub enum ExecuteMsg {
-    /// Delegate tokens that the contract holds evenly to the current validator set.
-    Bond {},
-
     /// Unbond the delegations.
     ///
     /// Can be invoked by anyone after `ending_time` is reached.
@@ -43,6 +51,16 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Return the contract configuration.
-    #[returns(Config)]
+    #[returns(ConfigResponse)]
     Config {},
+}
+
+#[cw_serde]
+pub struct ConfigResponse {
+    /// Denomination of the coin that will be staked.
+    pub bond_denom: String,
+
+    /// The ending time for the delegation program, as UNIX timestamp.
+    /// Unspecified until invokes the `bond` sudo method.
+    pub ending_time: Option<u64>,
 }

--- a/contracts/delegator/src/msg.rs
+++ b/contracts/delegator/src/msg.rs
@@ -61,6 +61,6 @@ pub struct ConfigResponse {
     pub bond_denom: String,
 
     /// The ending time for the delegation program, as UNIX timestamp.
-    /// Unspecified until invokes the `bond` sudo method.
+    /// Unspecified until governance invokes the `bond` sudo method.
     pub ending_time: Option<u64>,
 }

--- a/contracts/delegator/src/query.rs
+++ b/contracts/delegator/src/query.rs
@@ -1,7 +1,13 @@
 use cosmwasm_std::{Deps, StdResult};
 
-use crate::{msg::Config, state::CONFIG};
+use crate::{
+    msg::ConfigResponse,
+    state::{BOND_DENOM, ENDING_TIME},
+};
 
-pub fn query_config(deps: Deps) -> StdResult<Config> {
-    CONFIG.load(deps.storage)
+pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+    Ok(ConfigResponse {
+        bond_denom: BOND_DENOM.load(deps.storage)?,
+        ending_time: ENDING_TIME.may_load(deps.storage)?,
+    })
 }

--- a/contracts/delegator/src/state.rs
+++ b/contracts/delegator/src/state.rs
@@ -1,5 +1,5 @@
 use cw_storage_plus::Item;
 
-use crate::msg::Config;
+pub const BOND_DENOM: Item<String> = Item::new("bond_denom");
 
-pub const CONFIG: Item<Config> = Item::new("config");
+pub const ENDING_TIME: Item<u64> = Item::new("ending_time");


### PR DESCRIPTION
How the delegation contract currently works:

- The contract is instantiated and given 50M MARS in genesis
- Once the chain is started, anyone can call an execute function to make the delegation

The new suggested way:

- The contract is instantiated in genesis (but not given any MARS)
- Once the chain is started, one must create two governance proposals to start the delegation program:
  * A `CommunityPoolSpendProposal` to send 50M MARS to the contract
  * A `SudoContractProposal` to invoke the `bond` sudo method on the contract to make the delegations using tokens received in the previous step. The proposal should contain a list of validators to whom the delegations are to be made, and the ending time of the delegation program.

Note that there needs to be two proposals, because the gov module cannot send funds from the community pool to a contract and then execute the contract in the same proposal.