### PR TITLE
Delegator: make `bond` sudo-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "mars-delegator"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "mars-vesting"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["contracts/*"]
 
 [workspace.package]
-version       = "1.1.0"
+version       = "1.2.0"
 authors       = ["Larry Engineer <larry@delphidigital.io>"]
 edition       = "2021"
 rust-version  = "1.65"

--- a/contracts/delegator/examples/schema.rs
+++ b/contracts/delegator/examples/schema.rs
@@ -1,10 +1,11 @@
 use cosmwasm_schema::write_api;
 use cosmwasm_std::Empty;
-use mars_delegator::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use mars_delegator::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, SudoMsg};
 
 fn main() {
     write_api! {
         instantiate: InstantiateMsg,
+        sudo: SudoMsg,
         execute: ExecuteMsg,
         query: QueryMsg,
         migrate: Empty,

--- a/contracts/delegator/src/contract.rs
+++ b/contracts/delegator/src/contract.rs
@@ -25,8 +25,9 @@ pub fn instantiate(
 }
 
 #[entry_point]
-pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> StdResult<Response<MarsMsg>> {
+pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response<MarsMsg>, ContractError> {
     match msg {
+        SudoMsg::Bond {} => execute::bond(deps, env),
         SudoMsg::ForceUnbond {} => execute::force_unbond(deps, env),
     }
 }
@@ -39,7 +40,6 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response<MarsMsg>, ContractError> {
     match msg {
-        ExecuteMsg::Bond {} => execute::bond(deps, env),
         ExecuteMsg::Unbond {} => execute::unbond(deps, env),
         ExecuteMsg::Refund {} => execute::refund(deps, env),
     }

--- a/contracts/delegator/src/execute.rs
+++ b/contracts/delegator/src/execute.rs
@@ -35,7 +35,7 @@ pub fn bond(deps: DepsMut, env: Env) -> Result<Response<MarsMsg>, ContractError>
         .add_attribute("amount", format!("{amount}{}", cfg.bond_denom)))
 }
 
-pub fn force_unbond(deps: DepsMut, env: Env) -> StdResult<Response<MarsMsg>> {
+pub fn force_unbond(deps: DepsMut, env: Env) -> Result<Response<MarsMsg>, ContractError> {
     let msgs = get_undelegate_msgs(&deps.querier, &env.contract.address)?;
     Ok(Response::new()
         .add_messages(msgs)

--- a/contracts/delegator/src/execute.rs
+++ b/contracts/delegator/src/execute.rs
@@ -1,6 +1,4 @@
-use cosmwasm_std::{
-    coin, Addr, DepsMut, Env, QuerierWrapper, Response, StakingMsg, StdResult, Uint128,
-};
+use cosmwasm_std::{coin, Addr, DepsMut, Env, QuerierWrapper, Response, StakingMsg, StdResult};
 
 use crate::{error::ContractError, msg::Config, state::CONFIG, types::MarsMsg};
 
@@ -15,13 +13,7 @@ pub fn init(deps: DepsMut, cfg: Config) -> Result<Response, ContractError> {
 pub fn bond(deps: DepsMut, env: Env) -> Result<Response<MarsMsg>, ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
 
-    let amount = deps
-        .querier
-        .query_all_balances(env.contract.address)?
-        .into_iter()
-        .find(|coin| coin.denom == cfg.bond_denom)
-        .map(|coin| coin.amount)
-        .unwrap_or_else(Uint128::zero);
+    let amount = deps.querier.query_balance(env.contract.address, &cfg.bond_denom)?.amount;
 
     if amount.is_zero() {
         return Err(ContractError::NothingToBond);

--- a/contracts/delegator/src/msg.rs
+++ b/contracts/delegator/src/msg.rs
@@ -25,7 +25,7 @@ pub enum SudoMsg {
     ///
     /// This "sudo" message can only be invoked by the gov module, and ignores whether the
     /// `ending_time` has been reached.
-    ForceUnbond {},    
+    ForceUnbond {},
 }
 
 #[cw_serde]

--- a/contracts/delegator/src/msg.rs
+++ b/contracts/delegator/src/msg.rs
@@ -18,18 +18,18 @@ pub type InstantiateMsg = Config;
 
 #[cw_serde]
 pub enum SudoMsg {
+    /// Delegate tokens that the contract holds evenly to the current validator set.
+    Bond {},
+
     /// Forcibly unbond the delegations.
     ///
     /// This "sudo" message can only be invoked by the gov module, and ignores whether the
     /// `ending_time` has been reached.
-    ForceUnbond {},
+    ForceUnbond {},    
 }
 
 #[cw_serde]
 pub enum ExecuteMsg {
-    /// Delegate tokens that the contract holds evenly to the current validator set.
-    Bond {},
-
     /// Unbond the delegations.
     ///
     /// Can be invoked by anyone after `ending_time` is reached.

--- a/contracts/delegator/tests/tests.rs
+++ b/contracts/delegator/tests/tests.rs
@@ -116,6 +116,33 @@ fn instantiating() {
 }
 
 #[test]
+fn bonding() {
+    let mut deps = setup_test();
+
+    // this simulates governance giving the contract 25M MARS from community pool
+    deps.querier.update_balance(MOCK_CONTRACT_ADDR, coins(25_000_000_000_000, BOND_DENOM));
+
+    let res = sudo(deps.as_mut(), mock_env(), SudoMsg::Bond {}).unwrap();
+    assert_eq!(
+        res.messages,
+        vec![
+            SubMsg::new(StakingMsg::Delegate {
+                validator: "larry".into(),
+                amount: coin(8_333_333_333_334, BOND_DENOM),
+            }),
+            SubMsg::new(StakingMsg::Delegate {
+                validator: "jake".into(),
+                amount: coin(8_333_333_333_333, BOND_DENOM),
+            }),
+            SubMsg::new(StakingMsg::Delegate {
+                validator: "pumpkin".into(),
+                amount: coin(8_333_333_333_333, BOND_DENOM),
+            }),
+        ],
+    )
+}
+
+#[test]
 fn forced_unbonding() {
     let mut deps = setup_test();
 

--- a/schemas/mars-delegator/mars-delegator.json
+++ b/schemas/mars-delegator/mars-delegator.json
@@ -84,7 +84,40 @@
     "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
     "type": "object"
   },
-  "sudo": null,
+  "sudo": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "SudoMsg",
+    "oneOf": [
+      {
+        "description": "Delegate tokens that the contract holds evenly to the current validator set.",
+        "type": "object",
+        "required": [
+          "bond"
+        ],
+        "properties": {
+          "bond": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Forcibly unbond the delegations.\n\nThis \"sudo\" message can only be invoked by the gov module, and ignores whether the `ending_time` has been reached.",
+        "type": "object",
+        "required": [
+          "force_unbond"
+        ],
+        "properties": {
+          "force_unbond": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
   "responses": {
     "config": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/mars-delegator/mars-delegator.json
+++ b/schemas/mars-delegator/mars-delegator.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-delegator",
-  "contract_version": "1.1.0",
+  "contract_version": "1.2.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/mars-delegator/mars-delegator.json
+++ b/schemas/mars-delegator/mars-delegator.json
@@ -29,20 +29,6 @@
     "title": "ExecuteMsg",
     "oneOf": [
       {
-        "description": "Delegate tokens that the contract holds evenly to the current validator set.",
-        "type": "object",
-        "required": [
-          "bond"
-        ],
-        "properties": {
-          "bond": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Unbond the delegations.\n\nCan be invoked by anyone after `ending_time` is reached.",
         "type": "object",
         "required": [

--- a/schemas/mars-vesting/mars-vesting.json
+++ b/schemas/mars-vesting/mars-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-vesting",
-  "contract_version": "1.1.0",
+  "contract_version": "1.2.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This should be the only change needed for the 2nd month of community delegation.

The workflow:
- Devs multisig stores code & instantiates the contract. The ending time is specified in the instantiate msg;
- Governance passes a proposal to fund the contract with 25M MARS;
- Governance passes a proposal to invoke `SudoMsg::Bond`; the contract makes delegations evenly to all active validators
- Once ending time is reached: anyone can invoke `ExecuteMsg::Unbond` to initiate unbonding
- Once unbonding period has elapsed: anyone can invoke `ExecuteMsg::Refund` to return all funds to community pool

Question: should we filter off validators with >5% commission?