### PR TITLE
Fix migrate from version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "mars-delegator"
-version = "1.3.0"
+version = "1.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "mars-vesting"
-version = "1.3.0"
+version = "1.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 members = ["contracts/*"]
 
 [workspace.package]
-version       = "1.3.0"
 authors       = ["Larry Engineer <larry@delphidigital.io>"]
 edition       = "2021"
 rust-version  = "1.69"

--- a/contracts/delegator/Cargo.toml
+++ b/contracts/delegator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "mars-delegator"
 description   = "Smart contract managing community fund delegation to genesis validators on Mars Hub"
-version       = { workspace = true }
+version       = "1.2.0"
 authors       = { workspace = true }
 edition       = { workspace = true }
 rust-version  = { workspace = true }

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "mars-vesting"
 description   = "Smart contract managing token vesting for Mars protocol contributors"
-version       = { workspace = true }
+version       = "1.1.0"
 authors       = { workspace = true }
 edition       = { workspace = true }
 rust-version  = { workspace = true }

--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -11,7 +11,7 @@ use cw_utils::must_pay;
 use crate::{
     error::{Error, Result},
     helpers::{compute_position_response, compute_withdrawable},
-    migrations::v1_3_0,
+    migrations::v1_1_0,
     msg::{
         Config, ExecuteMsg, Position, PositionResponse, QueryMsg, Schedule, VotingPowerResponse,
     },
@@ -307,5 +307,5 @@ pub fn query_positions(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _: Env, _: Empty) -> Result<Response> {
-    v1_3_0::migrate(deps)
+    v1_1_0::migrate(deps)
 }

--- a/contracts/vesting/src/migrations/mod.rs
+++ b/contracts/vesting/src/migrations/mod.rs
@@ -1,1 +1,1 @@
-pub mod v1_3_0;
+pub mod v1_1_0;

--- a/contracts/vesting/src/migrations/v1_1_0.rs
+++ b/contracts/vesting/src/migrations/v1_1_0.rs
@@ -10,7 +10,7 @@ use crate::{
 
 const FROM_VERSION: &str = "1.0.0";
 
-pub mod v1_2_0_state {
+pub mod v1_0_0_state {
     use cosmwasm_std::Addr;
     use cw_storage_plus::Item;
 
@@ -27,9 +27,9 @@ pub fn migrate(deps: DepsMut) -> Result<Response> {
 
     // CONFIG updated, re-initializing
     let cfg = Config {
-        owner: v1_2_0_state::OWNER.load(deps.storage)?,
-        denom: v1_2_0_state::VEST_DENOM.into(),
-        unlock_schedule: v1_2_0_state::UNLOCK_SCHEDULE.load(deps.storage)?,
+        owner: v1_0_0_state::OWNER.load(deps.storage)?,
+        denom: v1_0_0_state::VEST_DENOM.into(),
+        unlock_schedule: v1_0_0_state::UNLOCK_SCHEDULE.load(deps.storage)?,
     };
 
     CONFIG.save(deps.storage, &cfg)?;

--- a/contracts/vesting/src/migrations/v1_3_0.rs
+++ b/contracts/vesting/src/migrations/v1_3_0.rs
@@ -8,7 +8,7 @@ use crate::{
     state::CONFIG,
 };
 
-const FROM_VERSION: &str = "1.2.0";
+const FROM_VERSION: &str = "1.0.0";
 
 pub mod v1_2_0_state {
     use cosmwasm_std::Addr;

--- a/contracts/vesting/tests/tests.rs
+++ b/contracts/vesting/tests/tests.rs
@@ -592,7 +592,7 @@ fn invalid_contract_version() {
 
     let old_contract_version = ContractVersion {
         contract: "crates.io:mars-vesting".to_string(),
-        version: "1.0.0".to_string(),
+        version: "0.9.0".to_string(),
     };
 
     set_contract_version(
@@ -605,8 +605,8 @@ fn invalid_contract_version() {
     let err = migrate(deps.as_mut(), env, Empty {}).unwrap_err();
     assert_eq!(
         Error::Version(VersionError::WrongVersion {
-            expected: "1.2.0".to_string(),
-            found: "1.0.0".to_string()
+            expected: "1.0.0".to_string(),
+            found: "0.9.0".to_string()
         }),
         err
     );
@@ -615,7 +615,7 @@ fn invalid_contract_version() {
 #[test]
 fn proper_migration() {
     let mut deps = mock_dependencies();
-    cw2::set_contract_version(deps.as_mut().storage, "crates.io:mars-vesting", "1.2.0").unwrap();
+    cw2::set_contract_version(deps.as_mut().storage, "crates.io:mars-vesting", "1.0.0").unwrap();
 
     let old_owner = "spiderman_246";
     v1_0_0_state::OWNER.save(deps.as_mut().storage, &Addr::unchecked(old_owner)).unwrap();
@@ -633,7 +633,7 @@ fn proper_migration() {
     assert!(res.data.is_none());
     assert_eq!(
         res.attributes,
-        vec![attr("action", "migrate"), attr("from_version", "1.2.0"), attr("to_version", "1.3.0"),]
+        vec![attr("action", "migrate"), attr("from_version", "1.0.0"), attr("to_version", "1.1.0"),]
     );
 
     let config = CONFIG.load(deps.as_ref().storage).unwrap();

--- a/contracts/vesting/tests/tests.rs
+++ b/contracts/vesting/tests/tests.rs
@@ -8,7 +8,7 @@ use cw_utils::PaymentError;
 use mars_vesting::{
     contract::{execute, instantiate, migrate, query},
     error::Error,
-    migrations::v1_3_0::v1_2_0_state,
+    migrations::v1_1_0::v1_0_0_state,
     msg::{
         Config, ExecuteMsg, Position, PositionResponse, QueryMsg, Schedule, VotingPowerResponse,
     },
@@ -618,14 +618,14 @@ fn proper_migration() {
     cw2::set_contract_version(deps.as_mut().storage, "crates.io:mars-vesting", "1.2.0").unwrap();
 
     let old_owner = "spiderman_246";
-    v1_2_0_state::OWNER.save(deps.as_mut().storage, &Addr::unchecked(old_owner)).unwrap();
+    v1_0_0_state::OWNER.save(deps.as_mut().storage, &Addr::unchecked(old_owner)).unwrap();
 
     let old_schedule = Schedule {
         start_time: 1614600000,
         cliff: 31536000,
         duration: 126144000,
     };
-    v1_2_0_state::UNLOCK_SCHEDULE.save(deps.as_mut().storage, &old_schedule).unwrap();
+    v1_0_0_state::UNLOCK_SCHEDULE.save(deps.as_mut().storage, &old_schedule).unwrap();
 
     let res = migrate(deps.as_mut(), mock_env(), Empty {}).unwrap();
 
@@ -637,7 +637,7 @@ fn proper_migration() {
     );
 
     let config = CONFIG.load(deps.as_ref().storage).unwrap();
-    assert_eq!(config.denom, v1_2_0_state::VEST_DENOM.to_string());
+    assert_eq!(config.denom, v1_0_0_state::VEST_DENOM.to_string());
     assert_eq!(config.owner.to_string(), old_owner.to_string());
     assert_eq!(config.unlock_schedule, old_schedule);
 }

--- a/schemas/mars-delegator/mars-delegator.json
+++ b/schemas/mars-delegator/mars-delegator.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-delegator",
-  "contract_version": "1.3.0",
+  "contract_version": "1.2.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/mars-vesting/mars-vesting.json
+++ b/schemas/mars-vesting/mars-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-vesting",
-  "contract_version": "1.3.0",
+  "contract_version": "1.1.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
`v1.2.0` was the version of the delegator contract. Vesting contract is still currently `v1.0.0`.

I think we shouldn't have a global version for all contracts. This PR let each contract have its own version.